### PR TITLE
docs: use `window.location.href` instead of `window.location` to avoid typescript error

### DIFF
--- a/docs/content/4.auth.md
+++ b/docs/content/4.auth.md
@@ -230,7 +230,7 @@ Return the correct URL to authenticate with provider.
 const { getProviderAuthenticationUrl } = useStrapiAuth()
 
 const onClick = () => {
-  window.location = getProviderAuthenticationUrl('github')
+  window.location.href = getProviderAuthenticationUrl('github')
 }
 </script>
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
**The problem:**
![CleanShot 2024-10-02 at 19 15 53@2x](https://github.com/user-attachments/assets/5e655750-1ddd-4017-92bc-bb5cfdc4c6b0)

**The fix:**
Use `window.location.href`. Ref: https://stackoverflow.com/q/75194714

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
